### PR TITLE
Fix for C++

### DIFF
--- a/libdebugnet/include/debugnet.h
+++ b/libdebugnet/include/debugnet.h
@@ -13,13 +13,17 @@
 #define ERROR 2
 #define DEBUG 3	
 
-
+#ifdef __cplusplus
+extern "C"
+{
+#endif
 
 int debugNetInit(char *serverIp, int port, int level);
 void debugNetFinish();
 void debugNetPrintf(int level, char* format, ...);
 void debugNetSetLogLevel(int level);
 
-
-
+#ifdef __cplusplus
+}
+#endif
 #endif


### PR DESCRIPTION
debugnet fails to link to C++ code without making sure the functions are defined with C linkage
