### PR TITLE
Fix inconsistent `const`  usage

### DIFF
--- a/libdebugnet/include/debugnet.h
+++ b/libdebugnet/include/debugnet.h
@@ -27,14 +27,14 @@ extern "C"
 #endif
 
 
-int debugNetInit(char *serverIp, int port, int level);
+int debugNetInit(const char *serverIp, int port, int level);
 int debugNetInitWithConf(debugNetConfiguration *conf);
 debugNetConfiguration *debugNetGetConf();
 int debugNetSetConf(debugNetConfiguration *conf);
 void debugNetFinish();
-void debugNetUDPSend(char *text);
-void debugNetUDPPrintf(char *format, ...);
-void debugNetPrintf(int level, char* format, ...);
+void debugNetUDPSend(const char *text);
+void debugNetUDPPrintf(const char *format, ...);
+void debugNetPrintf(int level, const char* format, ...);
 void debugNetSetLogLevel(int level);
 int debugNetCreateConf();
 

--- a/libdebugnet/source/debugnet.c
+++ b/libdebugnet/source/debugnet.c
@@ -53,7 +53,7 @@ void debugNetUDPPrintf(const char* fmt, ...)
  *
  * @param text - NULL-terminated buffer containing the raw text to send
  */
-void debugNetUDPSend(char *text)
+void debugNetUDPSend(const char *text)
 {
 	sceNetSend(dconfig->SocketFD, text, strlen(text), 0);
 }
@@ -68,7 +68,7 @@ void debugNetUDPSend(char *text)
  *
  * @param level - NONE,INFO,ERROR or DEBUG
  */
-void debugNetPrintf(int level, char* format, ...) 
+void debugNetPrintf(int level, const char* format, ...) 
 {
 	char msgbuf[0x800];
 	va_list args;
@@ -133,7 +133,7 @@ void debugNetSetLogLevel(int level)
  * @param port - udp port server
  * @param level - DEBUG,ERROR,INFO or NONE 
  */
-int debugNetInit(char *serverIp, int port, int level)
+int debugNetInit(const char *serverIp, int port, int level)
 {
     int ret=0;
     SceNetInitParam initparam;


### PR DESCRIPTION
`const` was used for the fmt argument of some functions but not others. One inconsistency introduced by #5 prevented compilation, it's fixed now.