### PR TITLE
Update to fix defines that collide with other commonly used defines.

### DIFF
--- a/libdebugnet/include/debugnet.h
+++ b/libdebugnet/include/debugnet.h
@@ -8,10 +8,10 @@
 
 #define NET_INIT_SIZE 1*1024*1024
 
-#define NONE 0
-#define INFO 1
-#define ERROR 2
-#define DEBUG 3	
+#define DBGNET_NONE 0
+#define DBGNET_INFO 1
+#define DBGNET_ERROR 2
+#define DBGNET_DEBUG 3	
 
 typedef struct debugNetConfiguration
 {

--- a/libdebugnet/source/debugnet.c
+++ b/libdebugnet/source/debugnet.c
@@ -63,10 +63,10 @@ void debugNetUDPSend(const char *text)
  *
  * @par Example:
  * @code
- * debugNetPrintf(INFO,"This is a %s test\n", "real");
+ * debugNetPrintf(DBGNET_INFO,"This is a %s test\n", "real");
  * @endcode
  *
- * @param level - NONE,INFO,ERROR or DEBUG
+ * @param level - DBGNET_NONE,DBGNET_INFO,DBGNET_ERROR or DBGNET_DEBUG
  */
 void debugNetPrintf(int level, const char* format, ...) 
 {
@@ -83,20 +83,20 @@ void debugNetPrintf(int level, const char* format, ...)
 	va_end(args);
 	if(level>dconfig->logLevel)
 	{
-		level=NONE;
+		level=DBGNET_NONE;
 	}
 	switch(level)
 	{
-		case INFO:
+		case DBGNET_INFO:
 	    	debugNetUDPPrintf("[VITA][INFO]: %s",msgbuf);  
 	        break;
-	   	case ERROR: 
+	   	case DBGNET_ERROR: 
 	    	debugNetUDPPrintf("[VITA][ERROR]: %s",msgbuf);
 	        break;
-		case DEBUG:
+		case DBGNET_DEBUG:
 	        debugNetUDPPrintf("[VITA][DEBUG]: %s",msgbuf);
 	        break;
-		case NONE:
+		case DBGNET_NONE:
 			break;
 	    default:
 		    debugNetUDPPrintf("%s",msgbuf);
@@ -108,9 +108,9 @@ void debugNetPrintf(int level, const char* format, ...)
  *
  * @par Example:
  * @code
- * debugNetSetLogLevel(DEBUG);  
+ * debugNetSetLogLevel(DBGNET_DEBUG);  
  * @endcode
- * @param level - DEBUG,ERROR,INFO or NONE 
+ * @param level - DBGNET_DEBUG,DBGNET_ERROR,DBGNET_INFO or DBGNET_NONE 
  */
 void debugNetSetLogLevel(int level)
 {
@@ -126,12 +126,12 @@ void debugNetSetLogLevel(int level)
  * @code
  * #define LOGLEVEL 3  
  * int ret;
- * ret = debugNetInit("172.26.0.2", 18194, DEBUG);
+ * ret = debugNetInit("172.26.0.2", 18194, DBGNET_DEBUG);
  * @endcode
  *
  * @param serverIP - your pc/mac server ip
  * @param port - udp port server
- * @param level - DEBUG,ERROR,INFO or NONE 
+ * @param level - DBGNET_DEBUG,DBGNET_ERROR,DBGNET_INFO or DBGNET_NONE 
  */
 int debugNetInit(const char *serverIp, int port, int level)
 {
@@ -237,9 +237,9 @@ int debugNetInitWithConf(debugNetConfiguration *conf)
 	ret=debugNetSetConf(conf);
 	if(ret)
 	{
-		debugNetPrintf(INFO,"debugnet already initialized using configuration from psp2link\n");
-		debugNetPrintf(INFO,"debugnet_initialized=%d SocketFD=%d logLevel=%d\n",dconfig->debugnet_initialized,dconfig->SocketFD,dconfig->logLevel);
-		debugNetPrintf(INFO,"ready to have a lot of fun...\n");
+		debugNetPrintf(DBGNET_INFO,"debugnet already initialized using configuration from psp2link\n");
+		debugNetPrintf(DBGNET_INFO,"debugnet_initialized=%d SocketFD=%d logLevel=%d\n",dconfig->debugnet_initialized,dconfig->SocketFD,dconfig->logLevel);
+		debugNetPrintf(DBGNET_INFO,"ready to have a lot of fun...\n");
 		return dconfig->debugnet_initialized;
 	}
 	else
@@ -255,7 +255,7 @@ int debugNetCreateConf()
 		dconfig=malloc(sizeof(debugNetConfiguration));
 		dconfig->debugnet_initialized=0;
 		dconfig->SocketFD = -1;
-		dconfig->logLevel=INFO;	
+		dconfig->logLevel=DBGNET_INFO;	
 		return 0;
 	}
 	

--- a/sample/main.c
+++ b/sample/main.c
@@ -13,10 +13,10 @@
 int main()
 {
 	int ret;
-	ret=debugNetInit(ip_server,port_server,DEBUG);
-	debugNetPrintf(DEBUG,"Test debug level %d\n",ret);
-	debugNetPrintf(ERROR,"Test error level %d\n",ret);
-	debugNetPrintf(INFO,"Test info level %d\n",ret);	
+	ret=debugNetInit(ip_server,port_server,DBGNET_DEBUG);
+	debugNetPrintf(DBGNET_DEBUG,"Test debug level %d\n",ret);
+	debugNetPrintf(DBGNET_ERROR,"Test error level %d\n",ret);
+	debugNetPrintf(DBGNET_INFO,"Test info level %d\n",ret);	
 	debugNetFinish();
 	sceKernelExitProcess(0);
 	return 0;


### PR DESCRIPTION
Recently I experienced the `#define`'s for log levels very badly conflicted with a library I was trying to port. Essentially, by defining them as such, it broke macros that had the words `DEBUG` or `ERROR` or `INFO` on them. 

The fix is to re-define the log levels with the library as a prefix. 

```c
#define NONE 0
#define INFO 1
#define ERROR 2
#define DEBUG 3	
```
becomes
```c
#define DBGNET_NONE 0
#define DBGNET_INFO 1
#define DBGNET_ERROR 2
#define DBGNET_DEBUG 3
```

This is important, the errors that are generated by these macros conflicting are vague and non-descript. Not to mention this library is bundled with VITASDK! 